### PR TITLE
Fix symfony 6.3 depreciation

### DIFF
--- a/DependencyInjection/CompilerPass/FormatsCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FormatsCompilerPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class FormatsCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $formats = $container->getDefinition('handcraftedinthealps_rest_routing.loader.yaml_collection')->getArgument(3);
 

--- a/DependencyInjection/CompilerPass/FormatsCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FormatsCompilerPass.php
@@ -15,6 +15,9 @@ namespace HandcraftedInTheAlps\RestRoutingBundle\DependencyInjection\CompilerPas
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @internal
+ */
 class FormatsCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void


### PR DESCRIPTION
# Descripition
Add type void to return function \FormatsCompilerPass::process()